### PR TITLE
Fixed the dead link of the Siebel Center direction

### DIFF
--- a/spring24/index.html
+++ b/spring24/index.html
@@ -21,7 +21,7 @@
                         <br>
                         <span class="fall-term">Spring 2024</span>
                         <p>
-                            <span class="time"> Friday 4-5pm, Siebel 1214 <a href="https://cs.illinois.edu/contact-us/directions-siebel-center", target="_blank">(direction)</a> </span>
+                            <span class="time"> Friday 4-5pm, Siebel 1214 <a href="https://publish.illinois.edu/siebelkiosk/files/2017/09/Siebel-Floor-Plan.pdf", target="_blank">(direction)</a> </span>
                         </p>
                     </div>
 


### PR DESCRIPTION
The [direction link](https://cs.illinois.edu/contact-us/directions-siebel-center) by the seminar room (Siebel 1214) is dead. Since I believe most people know where SC is and it is the specific room that is hard to locate, I propose to put a [link](https://publish.illinois.edu/siebelkiosk/files/2017/09/Siebel-Floor-Plan.pdf) to the floor plan instead.